### PR TITLE
expose the vector of start and end positions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,6 +227,12 @@ impl LinePositions {
 
         res
     }
+
+    /// The vector containing the start and end positions (in bytes) of every
+    /// line.
+    pub fn positions(&self) -> &Vec<(usize, usize)> {
+        &self.positions
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This change makes it possible to do the reverse too (get the start and end position from a line number).
I'm not sure if i should be the one to bump the version or not.